### PR TITLE
feat: localdev MODE=init|load with graceful-shutdown state dump

### DIFF
--- a/service_contracts/localdev/README.md
+++ b/service_contracts/localdev/README.md
@@ -54,12 +54,6 @@ The container operates in one of two modes, selected by the `MODE` env var.
 If `MODE` is unset, the entrypoint autodetects: load mode if
 `/app/anvil-state.json` is present, otherwise init mode.
 
-> **Breaking change**: the previous `DUMP_STATE=true` env var has been removed.
-> Use `MODE=init` instead. The critical behavioral difference is that init mode
-> now stays alive after deploying contracts (so external services can register
-> against the chain) and dumps state on graceful shutdown (SIGTERM), rather than
-> dumping immediately after deploy.
-
 ### Init Mode
 
 Deploys all contracts, starts the mock RPC server, then stays alive. On SIGTERM

--- a/service_contracts/localdev/README.md
+++ b/service_contracts/localdev/README.md
@@ -21,13 +21,25 @@ docker run -p 8545:8545 -e ANVIL_BLOCK_TIME=3 filecoin-localdev:local
 Uses pre-dumped state files to skip contract deployment:
 
 ```bash
-# First, generate state files (one-time)
-docker run --rm -v $(pwd):/output -e DUMP_STATE=true filecoin-localdev:local
+# Generate state files (one-time). The container stays alive after deploying
+# contracts; external services may register against the chain before you stop it.
+docker run -d --name localdev-init \
+  -p 8545:8545 \
+  -v $(pwd):/output \
+  -e MODE=init \
+  filecoin-localdev:local
 
-# Then run with state files
+# ... optionally run external services that register against the chain here ...
+
+# Graceful shutdown triggers the state dump:
+docker stop localdev-init
+docker rm localdev-init
+
+# Then run with the produced state files:
 docker run -p 8545:8545 \
   -v $(pwd)/anvil-state.json:/app/anvil-state.json \
   -v $(pwd)/deployed-addresses.json:/deployed-addresses.json \
+  -e MODE=load \
   -e ANVIL_BLOCK_TIME=3 \
   filecoin-localdev:local
 ```
@@ -38,30 +50,44 @@ docker run -p 8545:8545 \
 
 ## State Management
 
-The container supports three modes for flexible testing workflows.
+The container operates in one of two modes, selected by the `MODE` env var.
+If `MODE` is unset, the entrypoint autodetects: load mode if
+`/app/anvil-state.json` is present, otherwise init mode.
 
-### Mode 1: Normal Mode (Default)
+> **Breaking change**: the previous `DUMP_STATE=true` env var has been removed.
+> Use `MODE=init` instead. The critical behavioral difference is that init mode
+> now stays alive after deploying contracts (so external services can register
+> against the chain) and dumps state on graceful shutdown (SIGTERM), rather than
+> dumping immediately after deploy.
 
-Starts Anvil and deploys all contracts from scratch. Takes ~30 seconds but guarantees fresh state.
+### Init Mode
+
+Deploys all contracts, starts the mock RPC server, then stays alive. On SIGTERM
+(e.g. `docker stop`), state is dumped to `$OUTPUT_DIR` (default `/output`).
 
 ```bash
-docker run -p 8545:8545 filecoin-localdev:local
+docker run -d --name localdev \
+  -p 8545:8545 \
+  -v $(pwd):/output \
+  -e MODE=init \
+  filecoin-localdev:local
+
+# Optionally: run external services that call contract methods against
+# http://localhost:8545 — their state changes will be captured in the dump.
+
+docker stop localdev   # SIGTERM → dump
 ```
 
-### Mode 2: Dump Mode
+**Output files** (written to `$OUTPUT_DIR` on graceful shutdown):
+- `anvil-state.json` — Complete Anvil blockchain state (~2-10 MB)
+- `deployed-addresses.json` — Contract addresses for this deployment
 
-Deploys contracts, exports the complete chain state, then exits. Use this to generate state files for fast startup.
+**Safety**: if SIGTERM arrives while contract deployment is still in progress,
+the container exits non-zero and does NOT write state files. This prevents
+snapshotting a half-deployed chain. Only stop the container after your external
+registration flow has completed.
 
-```bash
-# Mount /output to receive the state files
-docker run --rm -v $(pwd):/output -e DUMP_STATE=true filecoin-localdev:local
-```
-
-**Output files:**
-- `anvil-state.json` - Complete Anvil blockchain state (~2-10 MB)
-- `deployed-addresses.json` - Contract addresses for this deployment
-
-### Mode 3: Load Mode
+### Load Mode
 
 Loads pre-existing state instead of deploying contracts. Starts in ~3 seconds.
 
@@ -69,13 +95,34 @@ Loads pre-existing state instead of deploying contracts. Starts in ~3 seconds.
 docker run -p 8545:8545 \
   -v /path/to/anvil-state.json:/app/anvil-state.json \
   -v /path/to/deployed-addresses.json:/deployed-addresses.json \
+  -e MODE=load \
   filecoin-localdev:local
 ```
 
 **Requirements:**
-- Both files must be mounted
+- Both files must be mounted (state file at `/app/anvil-state.json`, addresses
+  at `/deployed-addresses.json`)
 - Files must be from the same dump (matching state)
 - State format must be from `--dump-state` CLI (NOT `anvil_dumpState` RPC)
+
+**Opt-in state capture on shutdown**: if you bind-mount a writable directory at
+`/output`, the container writes the current in-memory anvil state (including
+any transactions applied since startup) to `$OUTPUT_DIR/anvil-state.json` on
+graceful shutdown (SIGTERM). This lets orchestrators capture a post-activity
+snapshot without re-deploying contracts. No mount → no write.
+
+```bash
+docker run -d --name localdev -p 8545:8545 \
+  -v $(pwd)/state/anvil-state.json:/app/anvil-state.json \
+  -v $(pwd)/state/deployed-addresses.json:/deployed-addresses.json \
+  -v $(pwd)/output:/output \
+  -e MODE=load \
+  filecoin-localdev:local
+
+# ... apply transactions via RPC ...
+
+docker stop localdev    # SIGTERM → anvil dumps current state to $(pwd)/output/
+```
 
 ### When to Regenerate State Files
 
@@ -148,10 +195,11 @@ cat deployed-addresses.json
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ANVIL_BLOCK_TIME` | `1` | Block mining interval in seconds |
+| `MODE` | autodetect | `init` (deploy + stay alive, dump on SIGTERM) or `load` (restore from state file). Autodetected from presence of `/app/anvil-state.json` when unset. |
+| `OUTPUT_DIR` | `/output` | Directory state files are written to on graceful shutdown in init mode. |
+| `ANVIL_BLOCK_TIME` | `3` | Block mining interval in seconds |
 | `ANVIL_PORT` | `8546` | Internal Anvil port |
 | `RPC_PORT` | `8545` | External RPC port |
-| `DUMP_STATE` | `false` | Set to `true` to run in dump mode |
 
 ### Contract Configuration
 
@@ -291,8 +339,21 @@ docker build -t filecoin-localdev:local -f Dockerfile ..
 # Build container
 docker build -t filecoin-localdev:local -f Dockerfile ..
 
-# Generate state files
-docker run --rm -v $(pwd):/output -e DUMP_STATE=true filecoin-localdev:local
+# Start in init mode (deploys contracts, stays alive)
+docker run -d --name localdev-gen \
+  -v $(pwd):/output \
+  -e MODE=init \
+  filecoin-localdev:local
+
+# Wait for healthy (contracts deployed, mockrpc ready)
+until [ "$(docker inspect -f '{{.State.Health.Status}}' localdev-gen)" = "healthy" ]; do sleep 1; done
+
+# Optionally: run any additional setup transactions against the chain here
+# so their state is captured in the snapshot.
+
+# Graceful stop triggers the state dump
+docker stop localdev-gen
+docker rm localdev-gen
 
 # Copy to your test directory
 cp anvil-state.json deployed-addresses.json /path/to/testdata/

--- a/service_contracts/localdev/docker-compose.yml
+++ b/service_contracts/localdev/docker-compose.yml
@@ -16,9 +16,13 @@ services:
       # Override with: ANVIL_BLOCK_TIME=30 docker-compose up -d
       - ANVIL_BLOCK_TIME=${ANVIL_BLOCK_TIME:-3}
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8545", "-X", "POST", "-H", "Content-Type: application/json", "-d", '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}']
+      # Sentinel file is touched by the entrypoint after contracts are deployed
+      # (init mode) or state is loaded (load mode) AND mockrpc is accepting
+      # requests. A port-probe healthcheck would flip healthy before contracts
+      # are deployed.
+      test: ["CMD", "test", "-f", "/tmp/ready"]
       interval: 5s
       timeout: 5s
       retries: 10
-      start_period: 30s
+      start_period: 60s
     restart: unless-stopped

--- a/service_contracts/localdev/entrypoint.sh
+++ b/service_contracts/localdev/entrypoint.sh
@@ -6,48 +6,190 @@ echo "Filecoin Local Development Environment"
 echo "=========================================="
 echo
 
+# ===========================================
 # Configuration
+# ===========================================
 ANVIL_PORT="${ANVIL_PORT:-8546}"
 RPC_PORT="${RPC_PORT:-8545}"
-ANVIL_BLOCK_TIME="${ANVIL_BLOCK_TIME:-1}"  # Default: 1 second
-STATE_FILE="/app/anvil-state.json"
-DUMP_STATE="${DUMP_STATE:-false}"
+ANVIL_BLOCK_TIME="${ANVIL_BLOCK_TIME:-3}"
+OUTPUT_DIR="${OUTPUT_DIR:-/output}"
 
-echo "Block mining: Every ${ANVIL_BLOCK_TIME}s"
-echo "Anvil port: $ANVIL_PORT (internal)"
-echo "RPC port: $RPC_PORT (external)"
+STATE_FILE_INPUT="/app/anvil-state.json"      # load-mode input (bind-mount target)
+STATE_FILE_DUMP="/tmp/anvil-state.json"       # anvil's --dump-state target
+ADDRESSES_FILE="/deployed-addresses.json"     # deploy-local.sh writes here
+READY_SENTINEL="/tmp/ready"                   # healthcheck target
+
+# ===========================================
+# Mode resolution
+# ===========================================
+# MODE=init  : deploy contracts, run mockrpc, dump state on SIGTERM
+# MODE=load  : load state file, run mockrpc, no dump on exit
+# MODE unset : autodetect — load if state file present, else init
+if [ -z "${MODE:-}" ]; then
+    if [ -f "$STATE_FILE_INPUT" ]; then
+        MODE="load"
+    else
+        MODE="init"
+    fi
+    echo "MODE not set, autodetected: $MODE"
+fi
+
+case "$MODE" in
+    init|load) ;;
+    *)
+        echo "ERROR: MODE must be 'init' or 'load' (got: $MODE)"
+        exit 1
+        ;;
+esac
+
+echo "Mode:             $MODE"
+echo "Block mining:     every ${ANVIL_BLOCK_TIME}s"
+echo "Anvil port:       $ANVIL_PORT (internal)"
+echo "RPC port:         $RPC_PORT (external)"
+if [ "$MODE" = "init" ]; then
+    echo "Output directory: $OUTPUT_DIR (state files written here on graceful shutdown)"
+fi
 echo
 
 # ===========================================
-# MODE 1: DUMP STATE MODE
-# Deploys contracts and exports state file
+# Shared helpers
 # ===========================================
-if [ "$DUMP_STATE" = "true" ]; then
-    echo "=========================================="
-    echo "DUMP STATE MODE"
-    echo "=========================================="
-    echo
-    echo "Will deploy contracts and export state to /output/anvil-state.json"
-    echo
-
-    # Start Anvil with --dump-state flag (writes JSON on exit)
-    anvil --host 0.0.0.0 --port $ANVIL_PORT --dump-state /tmp/anvil-state.json \
-          --block-time $ANVIL_BLOCK_TIME &
-    ANVIL_PID=$!
-
-    # Wait for Anvil to be ready
+wait_for_anvil() {
     echo "Waiting for Anvil to be ready..."
     for i in {1..30}; do
         if cast chain-id --rpc-url "http://localhost:$ANVIL_PORT" > /dev/null 2>&1; then
             echo "Anvil is ready!"
-            break
-        fi
-        if [ $i -eq 30 ]; then
-            echo "ERROR: Anvil failed to start"
-            exit 1
+            return 0
         fi
         sleep 0.5
     done
+    echo "ERROR: Anvil failed to start within 15 seconds"
+    return 1
+}
+
+wait_for_mockrpc() {
+    echo "Waiting for mockrpc to be ready..."
+    for i in {1..20}; do
+        if curl -sf "http://localhost:$RPC_PORT" \
+            -X POST -H "Content-Type: application/json" \
+            -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
+            > /dev/null 2>&1; then
+            echo "mockrpc is ready!"
+            return 0
+        fi
+        sleep 0.25
+    done
+    echo "ERROR: mockrpc failed to start within 5 seconds"
+    return 1
+}
+
+# ===========================================
+# INIT MODE: deploy + stay alive + dump on SIGTERM
+# ===========================================
+if [ "$MODE" = "init" ]; then
+    # Deploy-in-progress guard: if SIGTERM arrives while deploy-local.sh is
+    # running we must refuse to dump, otherwise we'd snapshot a half-deployed
+    # chain. Smelt is responsible for only stopping the container after it has
+    # observed registration completion, so arriving here early is genuinely
+    # a misuse and the non-zero exit is the right signal.
+    DEPLOY_IN_PROGRESS=1
+    ANVIL_PID=""
+    MOCKRPC_PID=""
+    DEPLOY_PID=""
+
+    init_cleanup() {
+        trap - TERM INT EXIT  # prevent recursion
+
+        if [ "$DEPLOY_IN_PROGRESS" = "1" ]; then
+            echo
+            echo "ERROR: Received SIGTERM during contract deployment — refusing to dump partial state."
+            echo "       Only send SIGTERM after external services have finished registering."
+            # deploy-local.sh runs in the background (so this trap can fire
+            # during a foreground forge/cast child); tear it down explicitly.
+            if [ -n "$DEPLOY_PID" ] && kill -0 "$DEPLOY_PID" 2>/dev/null; then
+                kill -TERM "$DEPLOY_PID" 2>/dev/null || true
+                wait "$DEPLOY_PID" 2>/dev/null || true
+            fi
+            [ -n "$ANVIL_PID" ] && kill -KILL "$ANVIL_PID" 2>/dev/null || true
+            exit 1
+        fi
+
+        echo
+        echo "=========================================="
+        echo "Graceful shutdown: dumping state"
+        echo "=========================================="
+
+        # Order matters: stop mockrpc first so no new registration txs sneak
+        # in after we've decided to snapshot, then stop anvil to trigger the
+        # --dump-state flush.
+        if [ -n "$MOCKRPC_PID" ] && kill -0 "$MOCKRPC_PID" 2>/dev/null; then
+            echo "Stopping mockrpc..."
+            kill -TERM "$MOCKRPC_PID" 2>/dev/null || true
+            wait "$MOCKRPC_PID" 2>/dev/null || true
+        fi
+
+        if [ -n "$ANVIL_PID" ] && kill -0 "$ANVIL_PID" 2>/dev/null; then
+            echo "Stopping anvil..."
+            kill -TERM "$ANVIL_PID" 2>/dev/null || true
+            wait "$ANVIL_PID" 2>/dev/null || true
+        fi
+
+        # Small fs sync window: anvil has just written --dump-state during
+        # its exit handler.
+        sleep 1
+
+        if [ ! -f "$STATE_FILE_DUMP" ]; then
+            echo "ERROR: anvil did not produce $STATE_FILE_DUMP on shutdown"
+            exit 1
+        fi
+
+        if [ ! -d "$OUTPUT_DIR" ]; then
+            mkdir -p "$OUTPUT_DIR" || {
+                echo "ERROR: cannot create OUTPUT_DIR=$OUTPUT_DIR (is it mounted?)"
+                exit 1
+            }
+        fi
+
+        # Atomic writes: cp to .tmp then mv. Prevents autodetect on a later
+        # boot from seeing a half-written state file and flipping to load mode.
+        cp "$STATE_FILE_DUMP" "$OUTPUT_DIR/anvil-state.json.tmp"
+        mv "$OUTPUT_DIR/anvil-state.json.tmp" "$OUTPUT_DIR/anvil-state.json"
+        cp "$ADDRESSES_FILE" "$OUTPUT_DIR/deployed-addresses.json.tmp"
+        mv "$OUTPUT_DIR/deployed-addresses.json.tmp" "$OUTPUT_DIR/deployed-addresses.json"
+        chmod 0644 "$OUTPUT_DIR/anvil-state.json" "$OUTPUT_DIR/deployed-addresses.json"
+
+        echo "State dumped to $OUTPUT_DIR/anvil-state.json"
+        echo "Addresses dumped to $OUTPUT_DIR/deployed-addresses.json"
+        ls -lh "$OUTPUT_DIR/anvil-state.json" "$OUTPUT_DIR/deployed-addresses.json"
+
+        echo
+        echo "=========================================="
+        echo "State Export Complete!"
+        echo "=========================================="
+        exit 0
+    }
+
+    trap init_cleanup TERM INT
+
+    # Ensure OUTPUT_DIR is writable now, not only at shutdown, so we fail
+    # fast rather than after minutes of registration activity.
+    if [ ! -d "$OUTPUT_DIR" ]; then
+        mkdir -p "$OUTPUT_DIR" || {
+            echo "ERROR: OUTPUT_DIR=$OUTPUT_DIR does not exist and cannot be created"
+            exit 1
+        }
+    fi
+
+    echo "=========================================="
+    echo "Starting fresh Anvil (init mode)"
+    echo "=========================================="
+    echo
+
+    anvil --host 0.0.0.0 --port "$ANVIL_PORT" --dump-state "$STATE_FILE_DUMP" \
+          --block-time "$ANVIL_BLOCK_TIME" --silent &
+    ANVIL_PID=$!
+
+    wait_for_anvil
 
     echo
     echo "=========================================="
@@ -55,170 +197,148 @@ if [ "$DUMP_STATE" = "true" ]; then
     echo "=========================================="
     echo
 
-    # Deploy contracts
-    ANVIL_RPC="http://localhost:$ANVIL_PORT" OUTPUT_FILE="/deployed-addresses.json" \
-        /app/service_contracts/localdev/scripts/deploy-local.sh
+    # Run deploy in background so the SIGTERM trap can fire during a forge
+    # subprocess. Foreground would block the trap until forge returns,
+    # letting docker's grace timeout expire and SIGKILL the container.
+    ANVIL_RPC="http://localhost:$ANVIL_PORT" OUTPUT_FILE="$ADDRESSES_FILE" \
+        /app/service_contracts/localdev/scripts/deploy-local.sh &
+    DEPLOY_PID=$!
+    # `wait` is interruptible — a trap fires immediately on SIGTERM arrival.
+    # set -e with `|| ...` preserves the child exit code for the failure path.
+    if ! wait "$DEPLOY_PID"; then
+        deploy_exit=$?
+        echo "ERROR: deploy-local.sh failed with exit $deploy_exit"
+        exit "$deploy_exit"
+    fi
+    DEPLOY_PID=""
+
+    DEPLOY_IN_PROGRESS=0
 
     echo
     echo "=========================================="
-    echo "Exporting State"
+    echo "Starting Mock Lotus RPC Server"
     echo "=========================================="
     echo
 
-    # Gracefully stop Anvil to trigger state dump
-    echo "Stopping Anvil to trigger state dump..."
-    kill -TERM $ANVIL_PID
+    export LISTEN_ADDR=":$RPC_PORT"
+    export ANVIL_ADDR="http://localhost:$ANVIL_PORT"
+    /app/mockrpc/mockrpc &
+    MOCKRPC_PID=$!
 
-    # Wait for Anvil to exit and write state file
-    wait $ANVIL_PID 2>/dev/null || true
+    wait_for_mockrpc
 
-    # Give filesystem a moment to sync
-    sleep 1
+    touch "$READY_SENTINEL"
 
-    # Check if state file was created
-    if [ ! -f /tmp/anvil-state.json ]; then
-        echo "ERROR: State file was not created!"
+    echo
+    echo "=========================================="
+    echo "Local Environment Ready!"
+    echo "=========================================="
+    echo
+    echo "Connect your application to:"
+    echo "  RPC URL:  http://localhost:$RPC_PORT"
+    echo "  Chain ID: 31337"
+    echo
+    echo "Contract addresses: cat $ADDRESSES_FILE"
+    echo
+    echo "Send SIGTERM (e.g. 'docker stop') to dump state to $OUTPUT_DIR"
+    echo
+
+    # Block until a signal arrives or a child exits unexpectedly. A child
+    # crash propagates non-zero through set -e and bypasses the trap's dump
+    # path — which is correct: we should not snapshot a degraded chain.
+    wait "$ANVIL_PID" "$MOCKRPC_PID"
+    exit $?
+fi
+
+# ===========================================
+# LOAD MODE: restore state + stay alive
+# ===========================================
+if [ "$MODE" = "load" ]; then
+    if [ ! -f "$STATE_FILE_INPUT" ]; then
+        echo "ERROR: MODE=load but $STATE_FILE_INPUT not found"
+        echo "       Mount a state file at $STATE_FILE_INPUT (e.g. via -v)"
         exit 1
     fi
 
-    # Copy to output mount
-    if [ -d /output ]; then
-        cp /tmp/anvil-state.json /output/anvil-state.json
-        cp /deployed-addresses.json /output/deployed-addresses.json
-        echo "State dumped to /output/anvil-state.json"
-        echo "Addresses dumped to /output/deployed-addresses.json"
-        ls -lh /output/anvil-state.json
-    else
-        echo "WARNING: /output directory not mounted!"
-        echo "State file is at /tmp/anvil-state.json inside container"
-    fi
-
-    echo
     echo "=========================================="
-    echo "State Export Complete!"
+    echo "Loading pre-existing state"
     echo "=========================================="
-    echo
-    echo "To use this state file:"
-    echo "  docker run -v \$(pwd)/anvil-state.json:/app/anvil-state.json filecoin-localdev"
-    echo
-    exit 0
-fi
-
-# ===========================================
-# MODE 2: LOAD STATE MODE
-# Fast startup with pre-existing state
-# ===========================================
-if [ -f "$STATE_FILE" ]; then
-    echo "=========================================="
-    echo "Loading Pre-existing State"
-    echo "=========================================="
-    echo
-    echo "Found state file at $STATE_FILE"
-    echo "Skipping contract deployment..."
+    echo "State file: $STATE_FILE_INPUT"
     echo
 
-    # Start Anvil with pre-loaded state
-    anvil --host 0.0.0.0 --port $ANVIL_PORT --load-state "$STATE_FILE" \
-          --block-time $ANVIL_BLOCK_TIME --silent &
+    # --dump-state lets smelt (or any orchestrator) capture the current
+    # in-memory chain state on graceful shutdown. Anvil writes the dump file
+    # during its own SIGTERM handler; we then copy it to OUTPUT_DIR if the
+    # caller mounted one. When OUTPUT_DIR isn't mounted the dump just sits in
+    # /tmp and is garbage-collected with the container.
+    anvil --host 0.0.0.0 --port "$ANVIL_PORT" --load-state "$STATE_FILE_INPUT" \
+          --dump-state "$STATE_FILE_DUMP" \
+          --block-time "$ANVIL_BLOCK_TIME" --silent &
     ANVIL_PID=$!
 
-    # Wait for Anvil to be ready
-    echo "Waiting for Anvil to load state..."
-    for i in {1..30}; do
-        if cast chain-id --rpc-url "http://localhost:$ANVIL_PORT" > /dev/null 2>&1; then
-            echo "Anvil is ready with loaded state!"
-            break
-        fi
-        if [ $i -eq 30 ]; then
-            echo "ERROR: Anvil failed to start with loaded state"
-            exit 1
-        fi
-        sleep 0.5
-    done
-
-# ===========================================
-# MODE 3: NORMAL MODE
-# Fresh deployment from scratch
-# ===========================================
-else
-    echo "=========================================="
-    echo "Starting Fresh Anvil Instance"
-    echo "=========================================="
-    echo
-    echo "No state file found, will deploy contracts..."
-    echo
-
-    # Start Anvil in background
-    anvil --host 0.0.0.0 --port $ANVIL_PORT --block-time $ANVIL_BLOCK_TIME --silent &
-    ANVIL_PID=$!
-
-    # Wait for Anvil to be ready
-    echo "Waiting for Anvil to be ready..."
-    for i in {1..30}; do
-        if cast chain-id --rpc-url "http://localhost:$ANVIL_PORT" > /dev/null 2>&1; then
-            echo "Anvil is ready!"
-            break
-        fi
-        if [ $i -eq 30 ]; then
-            echo "ERROR: Anvil failed to start"
-            exit 1
-        fi
-        sleep 0.5
-    done
+    wait_for_anvil
 
     echo
     echo "=========================================="
-    echo "Deploying Contracts"
+    echo "Starting Mock Lotus RPC Server"
     echo "=========================================="
     echo
 
-    # Deploy contracts
-    ANVIL_RPC="http://localhost:$ANVIL_PORT" OUTPUT_FILE="/deployed-addresses.json" \
-        /app/service_contracts/localdev/scripts/deploy-local.sh
+    export LISTEN_ADDR=":$RPC_PORT"
+    export ANVIL_ADDR="http://localhost:$ANVIL_PORT"
+    /app/mockrpc/mockrpc &
+    MOCKRPC_PID=$!
+
+    wait_for_mockrpc
+
+    touch "$READY_SENTINEL"
+
+    echo
+    echo "=========================================="
+    echo "Local Environment Ready!"
+    echo "=========================================="
+    echo
+    echo "Connect your application to:"
+    echo "  RPC URL:  http://localhost:$RPC_PORT"
+    echo "  Chain ID: 31337"
+    echo
+
+    load_cleanup() {
+        trap - TERM INT EXIT
+
+        # Mirror init-mode shutdown order: mockrpc first (stop traffic), then
+        # anvil (triggers --dump-state flush).
+        if [ -n "$MOCKRPC_PID" ] && kill -0 "$MOCKRPC_PID" 2>/dev/null; then
+            kill -TERM "$MOCKRPC_PID" 2>/dev/null || true
+            wait "$MOCKRPC_PID" 2>/dev/null || true
+        fi
+        if [ -n "$ANVIL_PID" ] && kill -0 "$ANVIL_PID" 2>/dev/null; then
+            kill -TERM "$ANVIL_PID" 2>/dev/null || true
+            wait "$ANVIL_PID" 2>/dev/null || true
+        fi
+        sleep 1  # fs sync after anvil exits
+
+        # Opt-in dump: when the caller bind-mounts a writable OUTPUT_DIR we
+        # persist the current state there so they can snapshot it. Silent no-op
+        # otherwise — users running the image for normal load-and-serve don't
+        # pay for a stray write.
+        if [ -f "$STATE_FILE_DUMP" ] && [ -d "$OUTPUT_DIR" ] && [ -w "$OUTPUT_DIR" ]; then
+            cp "$STATE_FILE_DUMP" "$OUTPUT_DIR/anvil-state.json.tmp"
+            mv "$OUTPUT_DIR/anvil-state.json.tmp" "$OUTPUT_DIR/anvil-state.json"
+            if [ -f "$ADDRESSES_FILE" ]; then
+                cp "$ADDRESSES_FILE" "$OUTPUT_DIR/deployed-addresses.json.tmp"
+                mv "$OUTPUT_DIR/deployed-addresses.json.tmp" "$OUTPUT_DIR/deployed-addresses.json"
+            fi
+            chmod 0644 "$OUTPUT_DIR/anvil-state.json" 2>/dev/null || true
+            [ -f "$OUTPUT_DIR/deployed-addresses.json" ] && \
+                chmod 0644 "$OUTPUT_DIR/deployed-addresses.json" 2>/dev/null || true
+            echo "Load-mode dump: state copied to $OUTPUT_DIR"
+        fi
+
+        exit 0
+    }
+    trap load_cleanup TERM INT
+
+    wait "$ANVIL_PID" "$MOCKRPC_PID"
+    exit $?
 fi
-
-echo
-echo "=========================================="
-echo "Starting Mock Lotus RPC Server"
-echo "=========================================="
-echo
-
-# Start the mock RPC server
-export LISTEN_ADDR=":$RPC_PORT"
-export ANVIL_ADDR="http://localhost:$ANVIL_PORT"
-
-/app/mockrpc/mockrpc &
-MOCKRPC_PID=$!
-
-# Wait a moment for the server to start
-sleep 1
-
-echo
-echo "=========================================="
-echo "Local Environment Ready!"
-echo "=========================================="
-echo
-echo "Connect your application to:"
-echo "  RPC URL: http://localhost:$RPC_PORT"
-echo "  Chain ID: 31337"
-echo
-echo "Contract addresses: cat /deployed-addresses.json"
-echo
-echo "Pre-funded Accounts:"
-echo "  Deployer:  0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
-echo "  Payer:     0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
-echo "  Provider:  0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
-echo
-
-# Handle shutdown
-cleanup() {
-    echo "Shutting down..."
-    kill $MOCKRPC_PID 2>/dev/null || true
-    kill $ANVIL_PID 2>/dev/null || true
-    exit 0
-}
-
-trap cleanup SIGTERM SIGINT
-
-# Keep container running
-wait $ANVIL_PID $MOCKRPC_PID


### PR DESCRIPTION
Rewrites the localdev container's entrypoint around two explicit modes so external orchestrators (storacha/smelt's snapshot feature) can drive post-deploy, post-registration state capture.

Modes:

- MODE=init: starts anvil with --dump-state, deploys contracts via deploy-local.sh, launches the mockrpc Filecoin proxy, and stays alive. On SIGTERM, a trap tears down mockrpc then anvil (in that order — mockrpc first so no late-arriving txs land in the snapshot), waits briefly for fs sync, then atomically copies anvil-state.json and deployed-addresses.json into $OUTPUT_DIR (default /output). The previous behavior killed anvil immediately after deploy — no window for external services to register before the dump.

- MODE=load: loads a pre-deployed state file, starts mockrpc, stays alive. Also runs anvil with --dump-state so graceful shutdown captures the current (possibly post-registration) state. When /output is mounted writable, the trap copies the dump there too; otherwise it's a silent no-op. Lets an orchestrator snapshot a running chain by issuing docker stop.

- MODE unset: autodetects (load if /app/anvil-state.json exists, else init). Keeps zero-config behavior working.

Other changes:

- Healthcheck in docker-compose.yml switched to `test -f /tmp/ready`. The sentinel is touched only after contracts are deployed (init) or state is loaded (load) AND mockrpc is accepting requests — more accurate than the previous eth_blockNumber port probe, which succeeded before contracts were available in init mode.
- OUTPUT_DIR is configurable (default /output).
- SIGTERM during deploy refuses to dump (DEPLOY_IN_PROGRESS guard + deploy-as-background-subprocess pattern so bash's trap fires promptly on signals rather than waiting for forge/cast children). Exits non-zero with a clear message rather than snapshotting a partially-deployed chain.
- Breaking change: the old DUMP_STATE=true env var is removed. Replaced by MODE=init.

README documents both modes and the opt-in dump-on-shutdown semantics of load mode.

> **Breaking change**: the previous `DUMP_STATE=true` env var has been removed.
> Use `MODE=init` instead. The critical behavioral difference is that init mode
> now stays alive after deploying contracts (so external services can register
> against the chain) and dumps state on graceful shutdown (SIGTERM), rather than
> dumping immediately after deploy.

